### PR TITLE
fix when no options provided

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,5 +3,5 @@ const loaderUtils = require('loader-utils')
 
 module.exports = function (source) {
   const options = loaderUtils.getOptions(this)
-  return vmark(source, options).component
+  return vmark(source, options || {}).component
 }

--- a/index.js
+++ b/index.js
@@ -2,6 +2,6 @@ const vmark = require('vmark')
 const loaderUtils = require('loader-utils')
 
 module.exports = function (source) {
-  const options = loaderUtils.getOptions(this)
-  return vmark(source, options || {}).component
+  const options = loaderUtils.getOptions(this) || {}
+  return vmark(source, options).component
 }


### PR DESCRIPTION
`loaderUtils.getOptions` returns `null` if no options provided, value that cannot be destructured and resulting in a `TypeError: Cannot match against 'undefined' or 'null'` error when run on vmark.